### PR TITLE
Added link to live version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The web app provides side-by-side examples of syntax differences between program
 
 All examples are executable. You can copy and launch them without changes. It helps to understand what the code is doing easily.
 
+View web app [here](http://evmorov.github.io/lang-compare).
+
 Created with:
 
 * [Middleman](https://middlemanapp.com)
@@ -75,4 +77,3 @@ Feel free to add or modify any examples.
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
-


### PR DESCRIPTION
Very simple. 

It just struck me that the readme didn't have the link to gh-pages, so I had to manually type them in. I did later see that it was at the top of the page in the header, but it is nice in the readme too I think.
